### PR TITLE
Create coppermine_to_dirstruct_skipper.py

### DIFF
--- a/coppermine-gallery-exporter/coppermine_to_dirstruct_skipper.py
+++ b/coppermine-gallery-exporter/coppermine_to_dirstruct_skipper.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+"""
+A script for exporting a Coppermine Photo Gallery to a directory structure
+"""
+
+from __future__ import print_function
+
+__author__ = "Markus Koskinen at futurice.com"
+__license__ = "BSD"
+
+import os
+import shutil
+import sys
+
+import MySQLdb
+
+_MYSQL_HOST = "localhost"
+_MYSQL_USER = "coppermine"
+_MYSQL_PASSWORD = "XAXAXAXAXAXAXA" # Insert your coppermine DB user password here
+_MYSQL_DB = "coppermine"
+
+_COPPERMINE_PATH = "/var/www/galerie.forte-net.cz"
+_TARGET_DIR = "/root/coppermine"
+
+
+def syntax(execname):
+    print("Syntax: %s [coppermine album path]" % execname)
+    sys.exit(1)
+
+
+def main():
+    global _COPPERMINE_PATH
+
+    db = MySQLdb.connect(host=_MYSQL_HOST,
+                         user=_MYSQL_USER,
+                         passwd=_MYSQL_PASSWORD,
+                         db=_MYSQL_DB)
+
+    cur = db.cursor()
+    cur.execute("""SELECT COUNT(filename) as filecount FROM cpg14345x_pictures;""")
+    total_files = cur.fetchall()[0]
+    cur.close()
+
+    cur = db.cursor()
+    cur.execute("""
+    SELECT REPLACE(REPLACE(alb.title, " ", "_"), "/", "-") AS albumname, CONCAT(pic.filepath, pic.filename) AS serverpath 
+        FROM cpg14345x_albums as alb, 
+             cpg14345x_pictures as pic 
+        WHERE pic.aid = alb.aid;
+    """)
+
+    if len(sys.argv) == 2:
+        _COPPERMINE_PATH = sys.argv[1]
+
+    if not os.path.exists(_TARGET_DIR):
+        os.mkdir(_TARGET_DIR)
+
+    print("Coppermine path: %s" % _COPPERMINE_PATH)
+
+    files, dirs = (0, 0)
+
+    print("Expecting %d files. Working..." % total_files)
+
+    for row in cur.fetchall():
+        album_name = row[0]
+
+        # Create target dir if it does not exist
+        target_dir = _TARGET_DIR + "/" + album_name
+
+        if not os.path.exists(target_dir):
+            os.mkdir(target_dir)
+            dirs += 1
+
+        source_path = _COPPERMINE_PATH + "/albums/" + row[1]
+
+        # Check if the source file exists, and skip if it doesn't
+        if not os.path.exists(source_path):
+            print("Skipping missing file: %s" % source_path)
+            continue
+
+        try:
+            shutil.copy2(source_path, target_dir)
+            files += 1
+            print("Copying file: %d" % files, end='\r')
+        except Exception as e:
+            print("Error copying file %s: %s" % (source_path, e))
+
+    print("Done. Files: %d New dirs: %d" % (files, dirs))
+
+
+if __name__ == "__main__":
+    if len(sys.argv) not in (1, 2):
+        syntax(sys.argv[0])
+
+    main()


### PR DESCRIPTION
Since I had a couple of files missing in my source folder, I created this modified version of the script.

In this modified version of the script, I added a try-except block around the shutil.copy2 function, which catches any exceptions that may be raised if the file cannot be copied. I also added a check to see if the source file exists, and if it doesn't, the script skips it and prints a message to the console which files it skipped.